### PR TITLE
Correcting SHA rules_go v0.39.0

### DIFF
--- a/chapter4/versions.bzl
+++ b/chapter4/versions.bzl
@@ -12,7 +12,7 @@ GO_VERSION = "1.20.2"
 # Rules_go
 # The last version and SHA256 can be found here: https://github.com/bazelbuild/rules_go/releases
 RULES_GO_VERSION = "v0.39.0"
-RULES_GO_SHA256 = "dd926a88a564a9246713a9c00b35315f54cbd46b31a26d5d8fb264c07045f05d"
+RULES_GO_SHA256 = "6b65cb7917b4d1709f9410ffe00ecf3e160edf674b78c54a894471320862184f"
 
 # Gazelle
 # The last version and SHA256 can be found here: https://github.com/bazelbuild/bazel-gazelle/blob/master/README.rst

--- a/chapter5/versions.bzl
+++ b/chapter5/versions.bzl
@@ -12,7 +12,7 @@ GO_VERSION = "1.20.2"
 # Rules_go
 # The last version and SHA256 can be found here: https://github.com/bazelbuild/rules_go/releases
 RULES_GO_VERSION = "v0.39.0"
-RULES_GO_SHA256 = "dd926a88a564a9246713a9c00b35315f54cbd46b31a26d5d8fb264c07045f05d"
+RULES_GO_SHA256 = "6b65cb7917b4d1709f9410ffe00ecf3e160edf674b78c54a894471320862184f"
 
 # Gazelle
 # The last version and SHA256 can be found here: https://github.com/bazelbuild/bazel-gazelle/blob/master/README.rst

--- a/chapter6/versions.bzl
+++ b/chapter6/versions.bzl
@@ -12,7 +12,7 @@ GO_VERSION = "1.20.2"
 # Rules_go
 # The last version and SHA256 can be found here: https://github.com/bazelbuild/rules_go/releases
 RULES_GO_VERSION = "v0.39.0"
-RULES_GO_SHA256 = "dd926a88a564a9246713a9c00b35315f54cbd46b31a26d5d8fb264c07045f05d"
+RULES_GO_SHA256 = "6b65cb7917b4d1709f9410ffe00ecf3e160edf674b78c54a894471320862184f"
 
 # Gazelle
 # The last version and SHA256 can be found here: https://github.com/bazelbuild/bazel-gazelle/blob/master/README.rst


### PR DESCRIPTION
Use SHA for rules_go as shown in https://github.com/bazelbuild/rules_go/releases/tag/v0.39.0